### PR TITLE
DEV-2357 Set retry connection parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mh-events2pulsar"
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ fn default_pulsar_namespace() -> String {
     String::from("default")
 }
 
-
 // XML structs
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,10 @@ async fn events(req_body: String, pulsar_client: web::Data<Mutex<PulsarClient>>)
                             // Create the Event struct
                             let premis_event = Event::new(&premis_event_xml);
                             // The topic part in: persistent://{tenant}/{namespace}/{topic}.
-                            let topic = format!("be.mediahaven.{}", &premis_event.event_type.to_lowercase());
+                            let topic = format!(
+                                "be.mediahaven.{}",
+                                &premis_event.event_type.to_lowercase()
+                            );
                             // Send message to Pulsar topic.
                             let send_message_result = pulsar_client
                                 .lock()


### PR DESCRIPTION
Sometimes, the connection is lost to the Pulsar server, resulting in a non-functioning application. Set default retry-connection params to restore the connection.

Also, run Cargo fmt.